### PR TITLE
Fixed bug where ProjectionX includes an extra bin

### DIFF
--- a/HeavyFlavourZCandleStudies.C
+++ b/HeavyFlavourZCandleStudies.C
@@ -311,7 +311,7 @@ TH1D *h1DHistoFrom2DTemplates(TString path2file,TString h2dname, TString name, d
 
   TFile *f2d = TFile::Open(path2file,"READONLY");
   TH2D  *h2d = (TH2D*)f2d->Get(h2dname); h2d->SetDirectory(0);
-  TH1D  *h1d = h2d->ProjectionX("h1d_"+h2dname,h2d->GetYaxis()->FindBin(ymin),h2d->GetYaxis()->FindBin(ymax),"e"); h1d->SetDirectory(0);
+  TH1D  *h1d = h2d->ProjectionX("h1d_"+h2dname,h2d->GetYaxis()->FindBin(ymin),h2d->GetYaxis()->FindBin(ymax)-1,"e"); h1d->SetDirectory(0);
   h1d->SetName(h2dname+"_"+name);
   h1d->SetLineColor(color);
   if (isdata) {


### PR DESCRIPTION
Hi,

I noticed a bug where ParticleNetSF may produce one-dimensional histograms from different pT ranges that can overlap and cause double-counting.

According to [this documentation](https://root.cern.ch/doc/master/classTH2.html#a974ece9e7d260f92df00a39dba14e5b0), the method `TH2::ProjectionX` projects `TH2` histograms from the first bin to the last bin, _inclusive_. This means if the end pT range is at the boundary of a bin, `h2d->GetYaxis()->FindBin(ymax)` will return the _next_ bin and introduces extra bins to the projection. 

For example, if the X axis on the 2D template is separated into 50 bins from 200 - 1200 GeV, the bins will be 20 GeV wide. Based on the original code, if we set the pT range for 1D histogram to be 300 - 400, `ProjectionX` will include bins 6 (300-320) to 10 (380-400) _and_ bin 11 (400-420), which is undesired.

In this fix, I reduced the bin number so that the excess bin would not be included by the projection by accident. Should you have any questions about this PR please let me know.

Thanks!
Vichayanun